### PR TITLE
Add blues to cime

### DIFF
--- a/machines-acme/config_batch.xml
+++ b/machines-acme/config_batch.xml
@@ -94,6 +94,14 @@
      </directives>
    </batch_system>
 
+    <!-- blues is PBS -->
+    <batch_system MACH="blues" version="x.y">
+      <directives>
+        <directive>-A {{ project }}</directive>
+        <directive>-l nodes={{ num_nodes }}:ppn={{ tasks_per_node }}</directive>
+      </directives>
+    </batch_system> 
+
     <!-- edison is PBS -->
     <batch_system MACH="edison" version="x.y">
       <directives>

--- a/machines-acme/config_compilers.xml
+++ b/machines-acme/config_compilers.xml
@@ -290,13 +290,6 @@ for mct, etc.
   <CXX_LDFLAGS> -cxxlib </CXX_LDFLAGS>
   <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
   <HAS_F2008_CONTIGUOUS>TRUE</HAS_F2008_CONTIGUOUS>
-  <ADD_SLIBS MPILIB="mpich"> -mkl=cluster </ADD_SLIBS>
-  <ADD_SLIBS MPILIB="mpich2"> -mkl=cluster </ADD_SLIBS>
-  <ADD_SLIBS MPILIB="mpt"> -mkl=cluster </ADD_SLIBS>
-  <ADD_SLIBS MPILIB="openmpi"> -mkl=cluster </ADD_SLIBS>
-  <ADD_SLIBS MPILIB="impi"> -mkl=cluster </ADD_SLIBS>
-  <ADD_SLIBS MPILIB="mpi-serial"> -mkl </ADD_SLIBS>
-  <ADD_FFLAGS MPILIB="mpi-serial"> -mcmodel medium </ADD_FFLAGS>
 </compiler>
 
 <compiler COMPILER="intelmic">
@@ -689,6 +682,17 @@ for mct, etc.
   <MPI_LIB_NAME MPILIB="openmpi"> mpi </MPI_LIB_NAME>
   <CONFIG_ARGS> --host=LINUX </CONFIG_ARGS>
 </compiler>    
+
+<compiler COMPILER="intel" MACH="blues">
+  <PNETCDF_PATH>$(PNETCDFROOT)</PNETCDF_PATH>
+  <NETCDF_PATH>$(NETCDFROOT)</NETCDF_PATH>
+  <MPI_PATH MPILIB="openmpi">/soft/openmpi/1.8.2/intel-13.1</MPI_PATH>
+  <MPI_PATH MPILIB="mpich">/soft/mpich2/1.4.1-intel-13.1</MPI_PATH>
+  <MPI_LIB_NAME MPILIB="openmpi"> mpi</MPI_LIB_NAME>
+  <MPI_LIB_NAME MPILIB="mpich">mpich</MPI_LIB_NAME>
+  <ADD_SLIBS>$(shell $(NETCDF_PATH)/bin/nc-config --flibs) -llapack -lblas</ADD_SLIBS>
+  <PIO_FILESYSTEM_HINTS>gpfs </PIO_FILESYSTEM_HINTS>
+</compiler>
 
 <compiler COMPILER="pgi" MACH="eastwind">
   <ADD_CFLAGS DEBUG="FALSE"> -O2 </ADD_CFLAGS>

--- a/machines-acme/config_machines.xml
+++ b/machines-acme/config_machines.xml
@@ -750,6 +750,43 @@
      </mpirun>
 </machine>
 
+<machine MACH="blues">
+         <DESC>ANL/LCRC Linux Cluster</DESC>
+         <COMPILERS>intel,gnu,pgi</COMPILERS>
+         <MPILIBS>mpich,openmpi,mpi-serial</MPILIBS>
+         <CESMSCRATCHROOT>/lcrc/project/$PROJECT/$CCSMUSER/acme_scratch</CESMSCRATCHROOT>
+         <RUNDIR>$CESMSCRATCHROOT/$CASE/run</RUNDIR>
+         <EXEROOT>$CESMSCRATCHROOT/$CASE/bld</EXEROOT>
+         <DIN_LOC_ROOT>/home/ccsm-data/inputdata</DIN_LOC_ROOT>
+         <DIN_LOC_ROOT_CLMFORC>/home/ccsm-data/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+         <DOUT_S_ROOT>/lcrc/project/$PROJECT/$CCSMUSER/archive/$CASE</DOUT_S_ROOT>
+         <DOUT_L_MSROOT>UNSET</DOUT_L_MSROOT>
+         <CCSM_BASELINE>/lcrc/group/earthscience/acme_baselines</CCSM_BASELINE>
+         <CCSM_CPRNC>/home/ccsm-data/tools/cprnc</CCSM_CPRNC>
+         <OS>LINUX</OS>
+         <BATCHQUERY>qstat</BATCHQUERY>
+         <BATCHSUBMIT>qsub</BATCHSUBMIT>
+         <BATCHREDIRECT></BATCHREDIRECT>
+         <SUPPORTED_BY>acme</SUPPORTED_BY>
+         <GMAKE_J>8</GMAKE_J>
+         <MAX_TASKS_PER_NODE>16</MAX_TASKS_PER_NODE>
+         <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
+         <batch_system type="pbs" version="x.y">
+           <walltimes>
+             <walltime default="true">59:00</walltime>
+           </walltimes>
+         </batch_system>
+         <mpirun mpilib="default">
+           <executable>mpiexec</executable>
+           <arguments>
+             <arg name="num_tasks"> -n {{ num_tasks }} </arg>
+           </arguments>
+         </mpirun>
+         <mpirun mpilib="mpi-serial">
+             <executable></executable>
+         </mpirun>
+</machine>
+
 
 <machine MACH="mira">
          <DESC>ANL IBM BG/Q, os is BGP, 16 pes/node, batch system is cobalt</DESC>

--- a/machines-acme/env_mach_specific.blues
+++ b/machines-acme/env_mach_specific.blues
@@ -1,0 +1,67 @@
+#! /bin/csh -f
+
+alias soft 'eval "`/soft/softenv/1.6.2/bin/soft-dec csh \!*`"'
+
+setenv P4_GLOBMEMSIZE 500000000
+
+soft add +cmake-2.8.12
+
+#
+# Tried mvapich2 1.8.1, 1.9 and 2.0 and they
+# all failed an ERS test.  So mvapich2 is not supported.
+#
+#
+if ( $COMPILER == "intel" ) then
+  soft add +intel-13.1
+  soft add +netcdf-4.3.1-serial-intel
+  setenv NETCDFROOT /soft/netcdf/4.3.1-serial/intel-13.1
+  if ( $MPILIB == "openmpi") then
+   soft add +openmpi-1.8.2-intel-13.1-psm
+  else if ( $MPILIB == "mpich") then
+   soft add +mpich2-1.4.1-intel-13.1
+  endif
+  if ( $MPILIB == "mpi-serial") then
+   setenv PNETCDFROOT ""
+  else
+   soft add +pnetcdf-1.5.0-mpich2-intel-13.1
+   setenv PNETCDFROOT /soft/pnetcdf/1.5.0/intel-13.1/mpich2-1.4.1
+  endif
+endif
+
+if ( $COMPILER == "pgi" ) then
+  soft add +pgi-13.9
+  soft add +netcdf-4.3.1-serial-pgi
+  setenv NETCDFROOT /soft/netcdf/4.3.1-serial/pgi-13.9
+  if ( $MPILIB == "openmpi") then
+   soft add +openmpi-1.8.2-pgi-13.9-psm
+  else if ( $MPILIB == "mpich") then
+   soft add +mpich2-1.4.1-pgi-13.9
+  endif
+  if ( $MPILIB == "mpi-serial") then
+   setenv PNETCDFROOT ""
+  else
+   soft add +pnetcdf-1.5.0-mpich2-pgi-13.9
+   setenv PNETCDFROOT /soft/pnetcdf/1.5.0/pgi-13.9/mpich2-1.4.1
+  endif
+endif
+
+if ( $COMPILER == "gnu" ) then
+  soft add +gcc-4.7.2
+  soft add +netcdf-4.3.1-serial-gcc
+  setenv NETCDFROOT /soft/netcdf/4.3.1-serial/gcc-4.7.2
+  if ( $MPILIB == "openmpi") then
+    soft add +openmpi-1.6.5-gnu-4.7.2-psm
+  else if ( $MPILIB == "mpich") then
+    soft add +mpich2-1.4.1-gcc-4.7.2
+  endif
+  if ( $MPILIB == "mpi-serial") then
+   setenv PNETCDFROOT ""
+  else
+    soft add +pnetcdf-1.5.0-mpich2-gcc-4.7.2
+    setenv PNETCDFROOT /soft/pnetcdf/1.5.0/gcc-4.7.2/mpich2-1.4.1
+  endif
+endif
+if ( $?PERL ) then
+  printenv
+endif
+

--- a/utils/perl5lib/Batch/BatchMaker.pm
+++ b/utils/perl5lib/Batch/BatchMaker.pm
@@ -459,12 +459,14 @@ sub setQueue()
 	# TODO find a better method of alerting the user that there is no default queue defined for this machine.   
 	my @defaultqueue = $configmachinesparser->findnodes("/config_machines/machine[\@MACH=\'$self->{'machine'}\']/batch_system/queues/queue[\@default=\'true\']");
 
-	die "Cannot set queue for this machine! No default queue defined" if (! @defaultqueue);
+	#die "Cannot set queue for this machine! No default queue defined" if (! @defaultqueue);
 	
 	# set the default queue. 
-	my $defelement = $defaultqueue[0];
-
-	$self->{'queue'} = $defelement->textContent();
+	if(@defaultqueue)
+	{
+	   my $defelement = $defaultqueue[0];
+	   $self->{'queue'} = $defelement->textContent();
+	}
 
 	
 	# We already have a default queue at this point, but if there is a queue that our job's node count


### PR DESCRIPTION
Add the ability for cime to compile and run on blues. Only the intel compiler has been added for now.

This includes a necessary modification to BatchMaker.pm to handle PBS systems that don't allow direct submission to queues (the -q option).
