### PR TITLE
Update machines-acme with needed features from cime2.0.12 machines.

### DIFF
--- a/machines-acme/Makefile
+++ b/machines-acme/Makefile
@@ -13,7 +13,9 @@ null  :=
 comma := ,
 
 # Load dependency search path.
-dirs := . $(shell cat Filepath)
+dirs := .
+dirs += $(shell cat Filepath)
+
 cpp_dirs := $(dirs)
 # Add INCROOT to path for Depends and Include
 MINCROOT := 
@@ -104,6 +106,33 @@ else
 endif
 ifeq ($(compile_threaded), true)
   CPPDEFS += -DTHREADED_OMP
+endif
+
+ifeq (,$(EXEROOT))
+  EXEROOT = $(shell ./xmlquery EXEROOT -value)
+endif
+ifeq (,$(BUILD_THREADED))
+  BUILD_THREADED = $(shell ./xmlquery BUILD_THREADED -value)
+endif
+
+ifeq (,$(LIBROOT))
+  LIBROOT = $(shell ./xmlquery LIBROOT -value)
+endif
+ifeq (,$(SHAREDLIBROOT))
+  SHAREDLIBROOT = $(shell ./xmlquery SHAREDLIBROOT -value)
+endif
+ifeq (,$(COMPILER))
+  COMPILER = $(shell ./xmlquery COMPILER -value)
+endif
+ifeq (,$(NINST_VALUE))
+  NINST_VALUE = $(shell ./xmlquery NINST_VALUE -value)
+endif
+ifeq (,$(MPILIB))
+  MPILIB = $(shell ./xmlquery MPILIB -value)
+endif
+
+ifeq (,$(SHAREDPATH))
+  SHAREDPATH = $(SHAREDLIBROOT)/$(COMPILER)/$(MPILIB)/$(DEBUGDIR)/$(THREADDIR)
 endif
 
 include $(CASEROOT)/Macros
@@ -286,16 +315,13 @@ ifeq ($(MODEL),driver)
 else
   ifeq ($(strip $(COMPILER)),nag)
     ifeq ($(DEBUG), TRUE)
+      ifeq ($(strip $(MACH)),hobart)
        # GCC needs to be able to link to
        # nagfor runtime to get autoconf
        # tests to work.
-       # No longer hard-coded to $(NAG), as we now have
-       # modules on goldbach. The modules on goldbach 
-       # now have $COMPILER_PATH defined, so we can 
-       # get the base path to the compiler without any 
-       # acrobatics.
-       CFLAGS += -Wl,--as-needed,--allow-shlib-undefined
-       SLIBS += -L$(COMPILER_PATH)/lib/NAG_Fortran -lf53
+        CFLAGS += -Wl,--as-needed,--allow-shlib-undefined
+        SLIBS += -L$(COMPILER_PATH)/lib/NAG_Fortran -lf60rts
+      endif
     endif
   endif
 endif
@@ -405,7 +431,7 @@ endif
 # ESMF_F90LINKRPATHS
 # ESMF_F90ESMFLINKLIBS
 ifeq ($(USE_ESMF_LIB), TRUE)
-  include $(CCSM_ESMFMKFILE)
+  -include $(CCSM_ESMFMKFILE)
   FFLAGS += $(ESMF_F90COMPILEPATHS)
   SLIBS  += $(ESMF_F90LINKPATHS) $(ESMF_F90LINKRPATHS) $(ESMF_F90ESMFLINKLIBS)
 endif
@@ -494,12 +520,13 @@ CMAKE_OPTS += -D CMAKE_Fortran_FLAGS:STRING="$(FFLAGS) $(INCLDIR)" \
               -D CMAKE_CXX_FLAGS:STRING="$(CXXFLAGS) $(INCLDIR)" \
               -D CMAKE_VERBOSE_MAKEFILE:BOOL=ON \
               -D NETCDF_DIR:STRING=$(NETCDF_PATH) \
-              -D USER_CMAKE_MODULE_DIR:STRING=$(CIMEROOT)/externals/CMake
+              -D GPTL_PATH:STRING=$(SHAREDPATH) \
+              -D USER_CMAKE_MODULE_PATH:STRING=$(CIMEROOT)/externals/CMake
 
 ifdef PNETCDF_PATH
 	CMAKE_OPTS += -D PNETCDF_DIR:STRING="$(PNETCDF_PATH)" 
 else
-        CMAKE_OPTS += -D WITH_PNETCDF:LOGICAL=FALSE
+        CMAKE_OPTS += -D WITH_PNETCDF:LOGICAL=FALSE -D PIO_USE_MPIIO:LOGICAL=FALSE
 endif
 ifdef PIO_FILESYSTEM_HINTS
 	CMAKE_OPTS += -D PIO_FILESYSTEM_HINTS:STRING="$(PIO_FILESYSTEM_HINTS)"
@@ -709,25 +736,62 @@ $(LIBROOT)/libcvmix.a:
 %.F90: %.F90.in
 	$(CIMEROOT)/externals/genf90/genf90.pl $< > $@
 
+cleanatm:
+	$(RM) -f $(LIBROOT)/libatm.a
+	cd $(EXEROOT)/atm/obj;  $(RM) -f *.o *.mod
 
-mostlyclean:
-	$(RM) -f *.f *.f90 
+cleancpl:
+	cd $(EXEROOT)/cesm/obj;  $(RM) -f *.o *.mod
 
-clean: mostlyclean
-	$(RM) -f *.d *.$(MOD_SUFFIX) $(OBJS) Srcfiles Filepath Deppath Depends
+cleanocn:
+	$(RM) -f $(LIBROOT)/libocn.a $(LIBROOT)/libcvmix.a
+	cd $(EXEROOT)/ocn/obj ; $(RM) -f *.o *.mod
 
-realclean: clean
-	$(RM) -f $(EXEC_SE)
+cleanwav:
+	$(RM) -f $(LIBROOT)/libwav.a
+	cd $(EXEROOT)/wav/obj ; $(RM) -f *.o *.mod
+
+cleanglc:
+	$(RM) -f $(LIBROOT)/libglc.a
+	$(RM) -fr $(EXEROOT)/glc
+
+cleanice:
+	$(RM) -f $(LIBROOT)/libice.a
+	cd $(EXEROOT)/ice/obj ; $(RM) -f *.o *.mod
+
+cleanrof:
+	$(RM) -f $(LIBROOT)/librof.a
+	cd $(EXEROOT)/rof/obj ; $(RM) -f *.o *.mod
+
+cleanlnd:
+	$(RM) -f $(LIBROOT)/liblnd.a
+	cd $(EXEROOT)/lnd/obj ; $(RM) -f *.o *.mod
+
+cleancsmshare:
+	$(RM) -f $(CSMSHARELIB)
+	$(RM) -fr $(SHAREDPATH)/$(COMP_INTERFACE)/$(ESMFDIR)/$(NINST_VALUE)/csm_share
+
+cleanpio:
+	$(RM) -f $(PIOLIB)
+	$(RM) -fr $(PIO_LIBDIR)
+
+cleanmct:
+	$(RM) -f $(MCTLIBS)
+	$(RM) -fr $(MCT_LIBDIR)
+
+cleangptl:
+	$(RM) -f $(GPTLLIB)
+	$(RM) -fr $(GPTL_LIBDIR)
+
+clean: cleanatm cleanocn cleanwav cleanglc cleanice cleanrof cleanlnd
+
+realclean: clean cleancsmshare cleanpio cleanmct cleangptl
 
 # the if-tests prevent DEPS files from being created when they're not needed
 ifneq ($(MAKECMDGOALS), db_files)
 ifneq ($(MAKECMDGOALS), db_flags)
-ifneq ($(MAKECMDGOALS), mostlyclean)
-ifneq ($(MAKECMDGOALS), clean)
-ifneq ($(MAKECMDGOALS), realclean)
+ifeq (,$(findstring clean,$(MAKECMDGOALS)))
     -include $(CURDIR)/Depends $(CASEROOT)/Depends.$(COMPILER) $(CASEROOT)/Depends.$(MACH) $(CASEROOT)/Depends.$(MACH).$(COMPILER)
-endif
-endif
 endif
 endif
 endif

--- a/machines-acme/buildlib.pio
+++ b/machines-acme/buildlib.pio
@@ -15,8 +15,9 @@ cd $pio_dir
 # Set options to cmake
 # ----------------------------------------------------------------------
 # Note that some other generic CMAKE options are set in the Makefile
-set cmake_opts=" -D USER_CMAKE_MODULE_PATH=$CIMEROOT/externals/CMake"
-set cmake_opts="$cmake_opts -D GENF90_PATH=$CIMEROOT/externals/genf90"
+#set cmake_opts=" -D USER_CMAKE_MODULE_PATH=$CIMEROOT/externals/CMake"
+#set cmake_opts="$cmake_opts -D GENF90_PATH=$CIMEROOT/externals/genf90"
+set cmake_opts=" -D GENF90_PATH=$CIMEROOT/externals/genf90"
 
 # ----------------------------------------------------------------------
 # create the pio makefile by running cmake (done via a rule
@@ -31,8 +32,9 @@ $GMAKE  $pio_dir/Makefile MODEL=pio USER_CMAKE_OPTS="$cmake_opts" \
 # ----------------------------------------------------------------------
 $GMAKE -j $GMAKE_J || exit 2
 if ( -d "$pio_dir/src" ) then
-  cp -p src/lib*.a $BLDROOT/lib
-  cp -p src/*.h src/*.mod $BLDROOT/include
+  cp -p $pio_dir/src/clib/libpioc.* $BLDROOT/lib
+  cp -p $pio_dir/src/flib/libpiof.* $BLDROOT/lib
+  cp -p $pio_dir/src/clib/*.h $pio_dir/src/flib/*.mod $BLDROOT/include
 else
   if( -d "$pio_dir/pio" ) then
     cd pio

--- a/machines-acme/config_compilers.xml
+++ b/machines-acme/config_compilers.xml
@@ -274,9 +274,11 @@ for mct, etc.
        system-level. (Note: I could not add this in the yellowstone-specific section,
        beacuse apparently that overrides rather than adds to this ADD_FFLAGS list.) -->
   <ADD_FFLAGS DEBUG="TRUE"> -O0 -g -check uninit -check bounds -check pointers -fpe0 -check noarg_temp_created </ADD_FFLAGS>
-  <ADD_FFLAGS DEBUG="FALSE"> -O2 </ADD_FFLAGS>
-  <FFLAGS>  -no-opt-dynamic-align  -convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model source </FFLAGS>
-  <CFLAGS> -O2  -no-opt-dynamic-align -fp-model precise </CFLAGS>
+  <ADD_FFLAGS DEBUG="FALSE"> -O2 -debug minimal </ADD_FFLAGS>
+  <ADD_CFLAGS DEBUG="FALSE"> -O2 -debug minimal </ADD_CFLAGS>
+  <ADD_CFLAGS DEBUG="TRUE"> -O0 -g </ADD_CFLAGS>
+  <FFLAGS>  -convert big_endian -assume byterecl -ftz -traceback -assume realloc_lhs -fp-model source </FFLAGS>
+  <CFLAGS> -O2 -fp-model precise </CFLAGS>
   <FFLAGS_NOOPT> -O0 </FFLAGS_NOOPT>
   <ADD_FFLAGS_NOOPT compile_threaded="true"> -openmp </ADD_FFLAGS_NOOPT>
   <FC_AUTO_R8> -r8 </FC_AUTO_R8>
@@ -290,6 +292,16 @@ for mct, etc.
   <CXX_LDFLAGS> -cxxlib </CXX_LDFLAGS>
   <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
   <HAS_F2008_CONTIGUOUS>TRUE</HAS_F2008_CONTIGUOUS>
+  <ADD_SLIBS MPILIB="mpich"> -mkl=cluster </ADD_SLIBS>
+  <ADD_SLIBS MPILIB="mpich2"> -mkl=cluster </ADD_SLIBS>
+  <ADD_SLIBS MPILIB="mpt"> -mkl=cluster </ADD_SLIBS>
+  <ADD_SLIBS MPILIB="openmpi"> -mkl=cluster </ADD_SLIBS>
+  <ADD_SLIBS MPILIB="impi"> -mkl=cluster </ADD_SLIBS>
+  <ADD_SLIBS MPILIB="mpi-serial"> -mkl </ADD_SLIBS>
+
+  <ADD_FFLAGS MPILIB="mpi-serial"> -mcmodel medium </ADD_FFLAGS>
+  <ADD_FFLAGS OS="Linux"> -mcmodel medium -shared-intel </ADD_FFLAGS>
+
 </compiler>
 
 <compiler COMPILER="intelmic">
@@ -333,9 +345,13 @@ for mct, etc.
   <FIXEDFLAGS>  -ffixed-form </FIXEDFLAGS>
   <FREEFLAGS> -ffree-form </FREEFLAGS>
   <ADD_FFLAGS DEBUG="TRUE"> -g -Wall </ADD_FFLAGS>
+  <ADD_FFLAGS DEBUG="FALSE"> -O </ADD_FFLAGS>
+  <ADD_CFLAGS DEBUG="TRUE"> -g -Wall </ADD_CFLAGS>
+  <ADD_CFLAGS DEBUG="FALSE"> -O </ADD_CFLAGS>
   <!-- -ffree-line-length-none and -ffixed-line-length-none need to be in FFLAGS rather than in FIXEDFLAGS/FREEFLAGS 
        so that these are passed to cmake builds (cmake builds don't use FIXEDFLAGS and FREEFLAGS). -->
-  <FFLAGS> -O -fconvert=big-endian -ffree-line-length-none -ffixed-line-length-none </FFLAGS>
+  <FFLAGS> -mcmodel=medium -fconvert=big-endian -ffree-line-length-none -ffixed-line-length-none </FFLAGS>
+  <CFLAGS> -mcmodel=medium </CFLAGS>
   <FFLAGS_NOOPT> -O0 </FFLAGS_NOOPT>
   <FC_AUTO_R8> -fdefault-real-8 </FC_AUTO_R8>
   <SFC> gfortran </SFC>

--- a/machines-acme/config_machines.xml
+++ b/machines-acme/config_machines.xml
@@ -112,7 +112,7 @@
          <GMAKE_J>8</GMAKE_J>
          <MAX_TASKS_PER_NODE>32</MAX_TASKS_PER_NODE>
          <PES_PER_NODE>16</PES_PER_NODE>
-         <batch_system name="pbs" version="x.y">
+         <batch_system type="pbs" version="x.y">
            <queues>
              <queue walltimemax="10:00:00" jobmin="1" jobmax="9999" default="true">regular</queue>
            </queues>
@@ -153,7 +153,7 @@
          <GMAKE_J>8</GMAKE_J>
          <MAX_TASKS_PER_NODE>192</MAX_TASKS_PER_NODE>
          <PES_PER_NODE>60</PES_PER_NODE>
-         <batch_system name="pbs" version="x.y">
+         <batch_system type="pbs" version="x.y">
            <queues>
              <queue walltimemax="04:00:00" jobmin="1" jobmax="9999" default="true">regular</queue>
            </queues>
@@ -230,7 +230,7 @@
          <SUPPORTED_BY>tcraig -at- ucar.edu</SUPPORTED_BY>
          <GMAKE_J>1</GMAKE_J>
          <MAX_TASKS_PER_NODE>16</MAX_TASKS_PER_NODE>
-         <batch_system name="pbs" version="x.y">
+         <batch_system type="pbs" version="x.y">
            <queues>
              <queue walltimemax="00:59:00" jobmin="1" jobmax="9999" default="true">batch</queue>
            </queues>
@@ -276,7 +276,7 @@
          <SUPPORTED_BY>tcraig -at- ucar.edu</SUPPORTED_BY>
          <GMAKE_J>8</GMAKE_J>
          <MAX_TASKS_PER_NODE>12</MAX_TASKS_PER_NODE>
-         <batch_system name="slurm" version="x.y">
+         <batch_system type="slurm" version="x.y">
            <queues>
              <queue jobmin="1" jobmax="9999" default="true">batch</queue>
            </queues>

--- a/machines-acme/configure
+++ b/machines-acme/configure
@@ -163,14 +163,13 @@ if (!$opts{'list'}) {
     if($opts{'output_format'}){
 	$output_format = $opts{'output_format'};
     }
-    if($opts{'cimeroot'}){
-	$cimeroot = $opts{'cimeroot'};
-    }
     if($opts{'mach_dir'}){
 	$machdir = $opts{'mach_dir'};
     }
 }
-
+if($opts{'cimeroot'}){
+$cimeroot = $opts{'cimeroot'};
+}
 $cimeroot = absolute_path($ENV{CIMEROOT}) unless defined($cimeroot);
 (-d "$cimeroot")  or  die <<"EOF";
 ** Cannot find cimeroot directory \"$cimeroot\"  

--- a/machines-acme/env_mach_specific.blues
+++ b/machines-acme/env_mach_specific.blues
@@ -14,6 +14,7 @@ soft add +cmake-2.8.12
 if ( $COMPILER == "intel" ) then
   soft add +intel-13.1
   soft add +netcdf-4.3.1-serial-intel
+  soft add +mkl
   setenv NETCDFROOT /soft/netcdf/4.3.1-serial/intel-13.1
   if ( $MPILIB == "openmpi") then
    soft add +openmpi-1.8.2-intel-13.1-psm

--- a/machines-acme/mkDepends
+++ b/machines-acme/mkDepends
@@ -327,15 +327,23 @@ sub find_dependencies {
     ($name, $path, $suffix) = fileparse($file, @suffixes);
     $target = "$name.o";
 
+    my $include;
     while ( <FH> ) {
 	# Search for "#include" and strip filename when found.
 	if ( /^#include\s+[<"](.*)[>"]/ ) {
-	     push @incs, $1;
+	    $include = $1;
 	 } 
 	# Search for Fortran include dependencies.
 	elsif ( /^\s*include\s+['"](.*)['"]/ ) {                   #" for emacs fontlock
-	     push @incs, $1;
+	    $include = $1;
 	}
+        if(defined($include)){
+            if($include =~ /shr_assert.h/){
+                push @mods, "$obj_dir".mangle_modfile("shr_assert_mod");
+            }
+            push @incs, $include;
+            undef $include;
+        }
 	# Search for module dependencies.
 	elsif ( /^\s*USE(?:\s+|\s*\:\:\s*|\s*,\s*non_intrinsic\s*\:\:\s*)(\w+)/i ) {
 	    # Return dependency in the form of a .mod file


### PR DESCRIPTION
mkDepends - clean up build issues with shr_assert_mod
Makefile - add clean options for individual components.
buildlib.pio - be able to build latest pio2
config_compilers.xml - add mkl and new debug/nodebug flags to intel.
add new debug/nodebug and mcmodel flags to gnu
config_machines.xml - change batch_system "name" to "type"
configure - check for "cimeroot" in all use cases.
env_mach_specific.blues - add +mkl for intel compiler.
