### PR TITLE
Changes needed for ACME

### DIFF
--- a/machines-acme/Makefile
+++ b/machines-acme/Makefile
@@ -326,10 +326,6 @@ else
   endif
 endif
 
-ifeq ($(COMP_OCN), pop)
-  INCLDIR += -I$(EXEROOT)/ocn/cvmix
-endif
-
 ifndef MCT_LIBDIR
   MCT_LIBDIR=$(SHAREDPATH)/mct
 endif
@@ -654,9 +650,6 @@ ifeq ($(ULIBDEP),$(null))
 
 
      ULIBDEP += $(LIBROOT)/libocn.a
-     ifeq ($(COMP_OCN), pop)
-       ULIBDEP += $(LIBROOT)/libcvmix.a
-     endif
      ULIBDEP += $(LIBROOT)/librof.a
      ULIBDEP += $(LIBROOT)/libglc.a
      ULIBDEP += $(LIBROOT)/libwav.a
@@ -717,9 +710,6 @@ $(EXEC_SE): $(OBJS) $(ULIBDEP) $(CSMSHARELIB) $(MCTLIBS) $(PIOLIB) $(GPTLLIB)
 $(COMPLIB): $(OBJS) 
 	$(AR) -r $(COMPLIB) $(OBJS)
 
-$(LIBROOT)/libcvmix.a:
-	$(MAKE) -f $(CIMEROOT)/../components/pop/source/cvmix/Makefile SRC_DIR=$(CIMEROOT)/../components/pop/source/cvmix FC=$(SFC) FCFLAGS="$(FFLAGS) $(FREEFLAGS)" LIB_DIR=$(LIBROOT)
-
 .c.o:
 	$(CC) -c $(INCLDIR) $(INCS) $(CFLAGS)  $<
 .F.o:
@@ -744,7 +734,7 @@ cleancpl:
 	cd $(EXEROOT)/cesm/obj;  $(RM) -f *.o *.mod
 
 cleanocn:
-	$(RM) -f $(LIBROOT)/libocn.a $(LIBROOT)/libcvmix.a
+	$(RM) -f $(LIBROOT)/libocn.a
 	cd $(EXEROOT)/ocn/obj ; $(RM) -f *.o *.mod
 
 cleanwav:

--- a/scripts/Tools/config_compsets.xml
+++ b/scripts/Tools/config_compsets.xml
@@ -17,7 +17,7 @@ Where
    ATM  = [CAM4, CAM5, DATM, SATM, XATM]
    LND  = [CLM40, CLM45, CLM50, DLND, SLND, XLND]
    ICE  = [CICE, DICE, SICE, SICE]
-   OCN  = [POP2, DOCN, SOCN, XOCN,AQUAP,MPAS]
+   OCN  = [POP, DOCN, SOCN, XOCN,AQUAP,MPAS]
    ROF  = [RTM, DROF, SROF, XROF]
    GLC  = [CISM1, CISM2S, CISM2P, SGLC, XGLC]
    WAV  = [WW3, DWAV, SWAV, XWAV]
@@ -429,7 +429,7 @@ value of RUN_STARTDATE will be date2.
 <COMP_ICE compset="_SICE">sice</COMP_ICE> 
 <COMP_ICE compset="_XICE">xice</COMP_ICE> 
 
-<COMP_OCN compset="_POP" >pop2</COMP_OCN> 
+<COMP_OCN compset="_POP" >pop</COMP_OCN> 
 <COMP_OCN compset="_DOCN">docn</COMP_OCN>
 <COMP_OCN compset="_SOCN">socn</COMP_OCN>
 <COMP_OCN compset="_XOCN">xocn</COMP_OCN>


### PR DESCRIPTION
From first merge attempt, know these changes will be needed.  They have no effect on the drv tests.

machines-acme/Makefile - remove cvmix references
scripts/Tools/config_compsets.xml - change POP2/pop2 to POP/pop
