### PR TITLE
Add cime_developer test suite

### DIFF
--- a/scripts-acme/update_acme_tests.py
+++ b/scripts-acme/update_acme_tests.py
@@ -50,6 +50,15 @@ _TEST_SUITES = {
                              "ERS.ne16_ne16.FC5ATMMOD")
                             ),
 
+    "cime_developer" : (None,
+                            ("NCK_Ld3.f45_g37_rx1.A",
+                             "ERI_D.f45_g37_rx1.A",
+                             "SEQ_PFC_Ld3.f09_g16.X",
+                             "ERS_Ld3.ne30_g16_rx1.A",
+                             "ERS_N2_Ld3.f19_g16_rx1.A",
+                             "ERS_Ld3.f45_g37_rx1.A")
+                            ),
+
     "acme_developer" : ("acme_land_developer",
                         ("ERS.f19_g16_rx1.A",
                          "ERS.f45_g37_rx1.DTEST",


### PR DESCRIPTION
The new cime_developer can be run with standalone CIME and the ACME create_test.
It has the same tests as the "prebeta drv" suite except:
ERI_D.T31_g37_rx1.A -> ERI_D.f45_g37_rx1.A
ERS_Ld3.T31_g37_rx1.A is removed.

All tests passed on blues,pgi.

[BFB]
